### PR TITLE
chore: add auto-branching and repo path to /commit and /pr

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,17 @@
+Commit changes in the b-log repo.
+
+1. **Review changes**: Run `git status` and `git diff` to see what's changed. Also check `git log --oneline -5` for recent commit style.
+
+2. **Stage relevant files**: Add the changed files. Do not stage files that contain secrets or credentials.
+
+3. **Commit**: Use conventional commit format based on the nature of the changes:
+   - `feat:` for new content or features
+   - `fix:` for bug fixes
+   - `chore:` for config, maintenance, tooling
+   - `docs:` for documentation updates
+   - `style:` for formatting/theme changes
+   - `refactor:` for restructuring without behavior change
+
+   Keep the message concise (1-2 sentences) focused on the "why."
+
+4. If there are no changes to commit, say so and stop.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,4 +1,4 @@
-Commit changes in the b-log repo. This command must be run from the repo clone directory (`/Users/bhavana/Documents/GitHub/personal/b-log`).
+Commit changes in the b-log repo. This command must be run from the repo clone directory.
 
 1. **Check branch**: If the current branch is `v4`, create a feature branch before committing:
    - Derive a short branch name from the staged changes (e.g., `feat/add-post-title`, `fix/broken-link`)

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,10 +1,14 @@
-Commit changes in the b-log repo.
+Commit changes in the b-log repo. This command must be run from the repo clone directory (`/Users/bhavana/Documents/GitHub/personal/b-log`).
 
-1. **Review changes**: Run `git status` and `git diff` to see what's changed. Also check `git log --oneline -5` for recent commit style.
+1. **Check branch**: If the current branch is `v4`, create a feature branch before committing:
+   - Derive a short branch name from the staged changes (e.g., `feat/add-post-title`, `fix/broken-link`)
+   - Run `git checkout -b <branch-name>`
 
-2. **Stage relevant files**: Add the changed files. Do not stage files that contain secrets or credentials.
+2. **Review changes**: Run `git status` and `git diff` to see what's changed. Also check `git log --oneline -5` for recent commit style.
 
-3. **Commit**: Use conventional commit format based on the nature of the changes:
+3. **Stage relevant files**: Add the changed files. Do not stage files that contain secrets or credentials.
+
+4. **Commit**: Use conventional commit format based on the nature of the changes:
    - `feat:` for new content or features
    - `fix:` for bug fixes
    - `chore:` for config, maintenance, tooling
@@ -14,4 +18,4 @@ Commit changes in the b-log repo.
 
    Keep the message concise (1-2 sentences) focused on the "why."
 
-4. If there are no changes to commit, say so and stop.
+5. If there are no changes to commit, say so and stop.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,15 @@
+Create a pull request for the current branch to v4.
+
+1. **Check state**: Run `git status`, `git branch`, and `git log v4..HEAD --oneline` to understand what's being proposed.
+
+2. **Push**: If the branch hasn't been pushed or is behind the remote, push with `-u`.
+
+3. **Create PR**: Use `gh pr create` targeting `v4` with:
+   - A short title (under 70 characters) using conventional commit style
+   - A body with:
+     - `## Summary` — bullet points of what changed
+     - `## Test plan` — how to verify the changes
+
+4. If the current branch is `v4`, tell the user to create a feature branch first and stop.
+
+5. Return the PR URL when done.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,4 +1,4 @@
-Create a pull request for the current branch to v4. This command must be run from the repo clone directory (`/Users/bhavana/Documents/GitHub/personal/b-log`).
+Create a pull request for the current branch to v4. This command must be run from the repo clone directory.
 
 1. **Check state**: Run `git status`, `git branch`, and `git log v4..HEAD --oneline` to understand what's being proposed.
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,15 +1,17 @@
-Create a pull request for the current branch to v4.
+Create a pull request for the current branch to v4. This command must be run from the repo clone directory (`/Users/bhavana/Documents/GitHub/personal/b-log`).
 
 1. **Check state**: Run `git status`, `git branch`, and `git log v4..HEAD --oneline` to understand what's being proposed.
 
-2. **Push**: If the branch hasn't been pushed or is behind the remote, push with `-u`.
+2. **Auto-branch**: If the current branch is `v4`, create a feature branch automatically:
+   - Derive a short branch name from the commits (e.g., `feat/add-post-title`, `fix/broken-link`)
+   - Run `git checkout -b <branch-name>`
 
-3. **Create PR**: Use `gh pr create` targeting `v4` with:
+3. **Push**: If the branch hasn't been pushed or is behind the remote, push with `-u`.
+
+4. **Create PR**: Use `gh pr create` targeting `v4` with:
    - A short title (under 70 characters) using conventional commit style
    - A body with:
      - `## Summary` — bullet points of what changed
      - `## Test plan` — how to verify the changes
-
-4. If the current branch is `v4`, tell the user to create a feature branch first and stop.
 
 5. Return the PR URL when done.

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,0 +1,22 @@
+Publish an Obsidian note to b-log.
+
+The user will provide the name or path of a note to publish. Follow these steps:
+
+1. **Find the note**: Look for the note in the `content/` directory of this repo. If the user gives a partial name, search for it. If the note doesn't exist, tell the user and stop.
+
+2. **Update frontmatter**: Set `draft: false` in the note's YAML frontmatter. If there is no frontmatter, add it. If `draft` is already `false`, tell the user the note is already published and ask if they want to continue anyway.
+
+3. **Create a feature branch**: Branch off `v4` with the naming convention `publish/<note-slug>` where `<note-slug>` is the note filename in kebab-case without the `.md` extension.
+
+4. **Commit**: Use conventional commit format: `feat: publish <note title>`
+   - Use the note's `title` from frontmatter if available, otherwise use the filename.
+
+5. **Push and open a PR**: Push the branch and open a PR to `v4` with:
+   - Title: `feat: publish <note title>`
+   - Body: A short summary noting which note is being published, with a link to it.
+
+6. **Merge the PR**: Merge the PR using squash merge, then delete the remote branch.
+
+7. **Clean up**: Switch back to the `v4` branch and pull latest.
+
+If anything fails at any step, stop and report the error clearly.

--- a/content/publishing-setup.md
+++ b/content/publishing-setup.md
@@ -1,0 +1,44 @@
+---
+title: publishing setup
+date: 2026-04-23
+draft: false
+tags: [meta, workflow]
+---
+
+obsidian for writing, quartz4 for building, github actions for deploying. notes live in `b-log/content/`, pushes to `v4` trigger a deploy.
+
+### workflow
+
+1. create a new note in obsidian using the template (starts with `draft: true`)
+2. write and iterate
+3. run `/publish <note-name>` in claude code when ready
+
+### custom claude code commands i set up
+
+`/publish` — the main one. sets `draft: false` in frontmatter, creates a `publish/<note-slug>` branch off `v4`, commits with conventional commit format (`feat: publish <title>`), opens a PR to `v4`, merges it, cleans up.
+
+`/commit` — stages and commits changes using conventional commits. picks the right prefix based on what changed:
+
+- `feat:` for new stuff
+- `fix:` for bugs
+- `chore:` for config and maintenance
+- `docs:` for documentation
+- `style:` for formatting/theme changes
+- `refactor:` for restructuring without behavior change
+
+`/pr` — pushes the current branch and opens a PR to `v4`. writes a summary and test plan in the body. useful when i want to review before merging instead of going straight through `/publish`.
+
+### note template
+
+every new note starts with:
+
+```yaml
+---
+title: 
+date: {{date}}
+draft: true
+tags: []
+---
+```
+
+notes stay hidden until published.

--- a/content/publishing-setup.md
+++ b/content/publishing-setup.md
@@ -17,7 +17,7 @@ obsidian for writing, quartz4 for building, github actions for deploying. notes 
 
 `/publish` — the main one. sets `draft: false` in frontmatter, creates a `publish/<note-slug>` branch off `v4`, commits with conventional commit format (`feat: publish <title>`), opens a PR to `v4`, merges it, cleans up.
 
-`/commit` — stages and commits changes using conventional commits. picks the right prefix based on what changed:
+`/commit` — stages and commits changes using conventional commits. if i'm on `v4`, it auto-creates a feature branch first (named from the changes, like `feat/add-post-title`). picks the right prefix based on what changed:
 
 - `feat:` for new stuff
 - `fix:` for bugs
@@ -26,7 +26,9 @@ obsidian for writing, quartz4 for building, github actions for deploying. notes 
 - `style:` for formatting/theme changes
 - `refactor:` for restructuring without behavior change
 
-`/pr` — pushes the current branch and opens a PR to `v4`. writes a summary and test plan in the body. useful when i want to review before merging instead of going straight through `/publish`.
+`/pr` — pushes the current branch and opens a PR to `v4`. if i'm on `v4`, it auto-creates a feature branch first. writes a summary and test plan in the body. useful when i want to review before merging instead of going straight through `/publish`.
+
+all three commands need to be run from the repo clone (`b-log/`).
 
 ### note template
 

--- a/content/templates/note.md
+++ b/content/templates/note.md
@@ -1,0 +1,6 @@
+---
+title: 
+date: {{date}}
+draft: true
+tags: []
+---

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -16,7 +16,7 @@ const config: QuartzConfig = {
     },
     locale: "en-US",
     baseUrl: "bhavanaeh.github.io",
-    ignorePatterns: ["private", "templates", ".obsidian"],
+    ignorePatterns: ["private", "templates", "content/templates", ".obsidian"],
     defaultDateType: "created",
     theme: {
       fontOrigin: "googleFonts",


### PR DESCRIPTION
## Summary
- `/commit` and `/pr` now auto-create a feature branch when run on `v4`
- Both commands document the required working directory
- Updated `publishing-setup.md` to reflect these changes

## Test plan
- Run `/commit` on `v4` with staged changes — verify it creates a branch before committing
- Run `/pr` on `v4` — verify it creates a branch before pushing/opening the PR