### PR TITLE
style: tweak publishing-setup and improve /commit flow

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,8 +1,9 @@
 Commit changes in the b-log repo. This command must be run from the repo clone directory.
 
-1. **Check branch**: If the current branch is `v4`, create a feature branch before committing:
-   - Derive a short branch name from the staged changes (e.g., `feat/add-post-title`, `fix/broken-link`)
-   - Run `git checkout -b <branch-name>`
+1. **Check branch**:
+   - If the current branch is `v4`, create a feature branch before committing.
+   - If the current branch already has a merged PR (check with `gh pr list --head <branch> --state merged`), stash changes, checkout `v4`, pull, create a new feature branch, and pop the stash.
+   - Derive a short branch name from the staged changes (e.g., `feat/add-post-title`, `fix/broken-link`).
 
 2. **Review changes**: Run `git status` and `git diff` to see what's changed. Also check `git log --oneline -5` for recent commit style.
 

--- a/quartz/content/publishing-setup.md
+++ b/quartz/content/publishing-setup.md
@@ -2,7 +2,7 @@
 title: publishing setup
 date: 2026-04-23
 draft: false
-tags: [meta, workflow]
+tags: [workflow]
 ---
 
 obsidian for writing, quartz4 for building, github actions for deploying. notes live in `b-log/quartz/content/`, pushes to `v4` trigger a deploy.
@@ -13,7 +13,7 @@ obsidian for writing, quartz4 for building, github actions for deploying. notes 
 2. write and iterate
 3. run `/publish <note-name>` in claude code when ready
 
-### custom claude code commands i set up
+### i set up the following commands (to start with)
 
 `/publish` — the main one. sets `draft: false` in frontmatter, creates a `publish/<note-slug>` branch off `v4`, commits with conventional commit format (`feat: publish <title>`), opens a PR to `v4`, merges it, cleans up.
 


### PR DESCRIPTION
## Summary
- Removed `#meta` tag from publishing-setup, kept `#workflow`
- Updated commands heading to be more conversational
- `/commit` now detects if the current branch's PR was already merged and creates a fresh branch off `v4`

## Test plan
- Verify publishing-setup renders with only `#workflow` tag
- Run `/commit` on a branch with a merged PR — should stash, checkout v4, and create a new branch