### PR TITLE
style: revert heading to custom claude code commands

### DIFF
--- a/quartz/content/publishing-setup.md
+++ b/quartz/content/publishing-setup.md
@@ -13,7 +13,7 @@ obsidian for writing, quartz4 for building, github actions for deploying. notes 
 2. write and iterate
 3. run `/publish <note-name>` in claude code when ready
 
-### i set up the following commands (to start with)
+### custom claude code commands
 
 `/publish` — the main one. sets `draft: false` in frontmatter, creates a `publish/<note-slug>` branch off `v4`, commits with conventional commit format (`feat: publish <title>`), opens a PR to `v4`, merges it, cleans up.
 


### PR DESCRIPTION
## Summary
- Changed commands heading from "i set up the following commands (to start with)" back to "custom claude code commands"

## Test plan
- Verify heading renders correctly on https://bhavanaeh.github.io/b-log/publishing-setup after merge