### PR TITLE
fix: heading revert and inline code visibility in light mode

### DIFF
--- a/quartz/content/publishing-setup.md
+++ b/quartz/content/publishing-setup.md
@@ -13,7 +13,7 @@ obsidian for writing, quartz4 for building, github actions for deploying. notes 
 2. write and iterate
 3. run `/publish <note-name>` in claude code when ready
 
-### i set up the following commands (to start with)
+### custom claude code commands
 
 `/publish` — the main one. sets `draft: false` in frontmatter, creates a `publish/<note-slug>` branch off `v4`, commits with conventional commit format (`feat: publish <title>`), opens a PR to `v4`, merges it, cleans up.
 

--- a/quartz/quartz.config.ts
+++ b/quartz/quartz.config.ts
@@ -30,10 +30,10 @@ const config: QuartzConfig = {
       colors: {
         lightMode: {
           light: "#f0e7d5",
-          lightgray: "#f0e7d5", // lightgray: "#e5e5e5",
+          lightgray: "#e4d9c5",
           gray: "#b8b8b8",
           darkgray: "#4e4e4e",
-          dark: "#284b63", // dark: "#2b2b2b", this is probably the header text color
+          dark: "#284b63",
           secondary: "#284b63",
           tertiary: "#84a59d",
           highlight: "rgba(143, 159, 169, 0.15)",


### PR DESCRIPTION
## Summary
- Reverted commands heading back to "custom claude code commands"
- Fixed inline code (`lightgray`) being invisible in light mode — was same color as page background

## Test plan
- Check publishing-setup page in light mode — inline code should have visible background
- Verify heading reads "custom claude code commands"